### PR TITLE
Add NTLM Express demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# ntlm
-express ntlm
+# NTLM Express Example
+
+This project demonstrates a simple Express.js server that uses NTLM authentication to retrieve the authenticated Windows username and display it.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install express express-ntlm
+   ```
+2. Start the server:
+   ```bash
+   node index.js
+   ```
+
+Navigate to `http://localhost:3000` and your NTLM username should be displayed.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const ntlm = require('express-ntlm');
+
+const app = express();
+
+app.use(ntlm());
+
+app.get('/', (req, res) => {
+  const user = req.ntlm ? req.ntlm.UserName : 'Anonymous';
+  res.send(`Hello ${user}`);
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ntlm",
+  "version": "1.0.0",
+  "description": "express ntlm",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- add Express/NTLM sample server
- document setup
- ignore node_modules
- add start script in package.json

## Testing
- `npm install express express-ntlm` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c6ab962f083259cf13f2daa8897d0